### PR TITLE
Deprecate the atomicfile package

### DIFF
--- a/atomicfile/file.go
+++ b/atomicfile/file.go
@@ -4,6 +4,9 @@
 /*
 Package atomicfile provides a simple API to atomically (over)write a file.
 
+Deprecated: Please use github.com/google/renameio and github.com/mkmik/filetransformer
+instead.
+
 The content is first written in a temporary file and only after the file is fully written
 the old file is replaced by renaming the temporary file over it. The operation is atomic
 (i.e. every external process will either see the old file or the new file, never anything

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vmware-labs/go-yaml-edit
 go 1.14
 
 require (
+	github.com/mkmik/filetransformer v0.1.0
 	github.com/vmware-labs/yaml-jsonpointer v0.1.0
 	golang.org/x/text v0.3.2
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm7232
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
+github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -15,6 +17,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mkmik/filetransformer v0.1.0 h1:J5wzpkNGQ2b3LVv7pFjl4mBvYHkiDfIm2qYFxUlNvgs=
+github.com/mkmik/filetransformer v0.1.0/go.mod h1:xMdmMwoBNGIIiOmilq8RPhAVpENKJLoV7MxECjwzV/k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
And add some docs to the examples that mention the package to be imported in order
to perform a in-place file edit (which matters since online go documentation viewers such as pkg.dev.go
only show the body of the Example functions and not the import section).

Signed-off-by: Marko Mikulicic <mkmik@vmware.com>